### PR TITLE
Fix reference to typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "String Tokenization Library for JavaScript",
     "keywords":    [ "string", "token", "scanner", "lexer" ],
     "main":        "lib/tokenizr.js",
-    "types":       "lib/tokenizr.d.ts",
+    "types":       "src/tokenizr.d.ts",
     "repository": {
         "type": "git",
         "url":  "https://github.com/rse/tokenizr.git"


### PR DESCRIPTION
The reference to the typings file in `package.json` points to the wrong path. This pull request should fix that.