### PR TITLE
Fix type definition

### DIFF
--- a/src/tokenizr.d.ts
+++ b/src/tokenizr.d.ts
@@ -97,8 +97,8 @@ export default class Tokenizr {
     before(action: Action): this
     after(action: Action): this
     finish(action: (this: ActionContext, ctx: ActionContext) => void): this
-    rule(state: string, pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: string[]) => void, name?: string): this
-    rule(pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: string[]) => void, name?: string): this
+    rule(state: string, pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: RegExpExecArray) => void, name?: string): this
+    rule(pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: RegExpExecArray) => void, name?: string): this
     token(): Token
     tokens(): Token[]
     peek(offset?: number): Token


### PR DESCRIPTION
The `match` param on the `Tokenizr.rule` method currently uses `string[]`.

```
export default class Tokenizr {
  rule(state: string, pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: string[]) => void, name?: string): this
  rule(pattern: RegExp, action: (this: ActionContext, ctx: ActionContext, match: string[]) => void, name?: string): this
}
```

The `match` param is the executed response of `https://github.com/rse/tokenizr/blob/a96015def19a23ac74a3335d762effe46d149f51/src/tokenizr.js#L517` which returns a RegExpExecArray

This PR fixes the definition